### PR TITLE
Proxy to avoid using Google API library for CORS

### DIFF
--- a/service-jehlomat/build.gradle.kts
+++ b/service-jehlomat/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
 
     // Koin DI
     implementation("org.koin:koin-ktor:2.0.1")
+
+    // Http client
+    implementation("com.github.kittinunf.fuel:fuel:2.2.1")
 }
 
 tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {

--- a/service-jehlomat/src/main/kotlin/api/GooglePlacesProxy.kt
+++ b/service-jehlomat/src/main/kotlin/api/GooglePlacesProxy.kt
@@ -1,0 +1,40 @@
+package api
+
+import com.github.kittinunf.fuel.Fuel
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.util.*
+
+fun Route.googlePlacesProxy(): Route {
+    return route("/proxy") {
+        get("/autocomplete") {
+            val parameters = call.request.queryParameters.flattenEntries()
+
+            val (_, response, result) = Fuel.get(
+                path = "https://maps.googleapis.com/maps/api/place/autocomplete/json",
+                parameters = parameters
+            ).responseString()
+
+            call.respondText(
+                contentType = ContentType.Application.Json,
+                status = HttpStatusCode(response.statusCode, "")
+            ) { result.get() }
+        }
+
+        get("/details") {
+            val parameters = call.request.queryParameters.flattenEntries()
+
+            val (_, response, result) = Fuel.get(
+                path = "https://maps.googleapis.com/maps/api/place/details/json",
+                parameters = parameters
+            ).responseString()
+
+            call.respondText(
+                contentType = ContentType.Application.Json,
+                status = HttpStatusCode(response.statusCode, "")
+            ) { result.get() }
+        }
+    }
+}

--- a/service-jehlomat/src/main/kotlin/main/Application.kt
+++ b/service-jehlomat/src/main/kotlin/main/Application.kt
@@ -1,5 +1,6 @@
 package main
 
+import api.googlePlacesProxy
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.joda.JodaModule
 import io.ktor.application.*
@@ -48,6 +49,9 @@ fun Application.module(testing: Boolean = false) {
     }
 
     routing {
+        route("/api/v1/jehlomat") {
+            googlePlacesProxy()
+        }
         get("/") {
             call.respond("service-jehlomat")
         }

--- a/web-jehlomat/src/main/kotlin/app/AppProductionDependencies.kt
+++ b/web-jehlomat/src/main/kotlin/app/AppProductionDependencies.kt
@@ -13,7 +13,8 @@ val productionModule = module {
 
     single<IPlaces> {
         GoogleMapsPlaces(
-            googleMapsKey = get<IConfig>().get().googleMapsKey
+            googleMapsKey = get<IConfig>().get().googleMapsKey,
+            baseUrl = get<IConfig>().get().jehlomatServiceUrl
         )
     }
 }

--- a/web-jehlomat/src/main/kotlin/services/places/GoogleMapsPlaces.kt
+++ b/web-jehlomat/src/main/kotlin/services/places/GoogleMapsPlaces.kt
@@ -11,7 +11,8 @@ import kotlinx.serialization.json.Json
 import services.buildParametersString
 
 class GoogleMapsPlaces(
-    val googleMapsKey: String
+    val googleMapsKey: String,
+    val baseUrl: String
 ) : IPlaces {
 
     override fun autocomplete(
@@ -29,7 +30,7 @@ class GoogleMapsPlaces(
         )
 
         val request = Request(
-            input = "https://maps.googleapis.com/maps/api/place/autocomplete/json?$parameters",
+            input = "${baseUrl}/proxy/autocomplete?$parameters",
             init = RequestInit(
                 method = "GET"
             )
@@ -75,7 +76,7 @@ class GoogleMapsPlaces(
         )
 
         val request = Request(
-            input = "https://maps.googleapis.com/maps/api/place/details/json?$parameters",
+            input = "${baseUrl}/proxy/details?$parameters",
             init = RequestInit(
                 method = "GET"
             )

--- a/web-jehlomat/src/main/kotlin/utils/Config.kt
+++ b/web-jehlomat/src/main/kotlin/utils/Config.kt
@@ -22,8 +22,8 @@ class LocalConfig : IConfig {
 class ProductionConfig : IConfig {
     override fun get(): Config {
         return Config(
-            userServiceUrl = "https://app.jehlomat.cz/api/v1/users",
-            jehlomatServiceUrl = "https://app.jehlomat.cz/api/v1/jehlomat",
+            userServiceUrl = "/api/v1/users",
+            jehlomatServiceUrl = "/api/v1/jehlomat",
             googleMapsKey = when (process.env.GOOGLE_MAPS_KEY) {
                 undefined -> {
                     throw Exception("Missing GOOGLE_MAPS_KEY env variable.")


### PR DESCRIPTION
Rychla implementace proxy pro Google Places API.

Rozhodoval jsem se mezi:
- Obecnou proxy (CORS anywhere)
- Vlastni proxy na  stejne URL
- Pouziti Google API knihovny

Vlastni proxy mi prislo nejlepsi reseni, je to bezpecne (nejde to pouzit k utoku jako obecna proxy) a neni treba resit extra knihovnu. 

Neresil jsem detaily implementace, slo mi o rychlou moznost prubezne testovat na https://jehlomat.ceskodigital.net. Az budeme resit Backend, muzeme to napsat lepe.