### PR TITLE
Upgraded dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Run application locally
+
+```shell
+./gradlew run --parallel
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ allprojects {
         maven { setUrl("http://dl.bintray.com/kotlin/kotlinx.html") }
         maven { setUrl("http://dl.bintray.com/kotlin/kotlin-js-wrappers") }
         maven { setUrl("http://dl.bintray.com/kotlin/kotlinx") }
-        maven { url = uri("https://dl.bintray.com/ekito/koin") }
     }
 
     configurations.all {

--- a/web-jehlomat/build.gradle.kts
+++ b/web-jehlomat/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation("org.jetbrains:kotlin-styled:5.2.0-pre.142-kotlin-1.4.21")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.0.1")
-    implementation("org.koin:koin-core:3.0.1-alpha-3")
+    implementation("io.insert-koin:koin-core:3.1.1")
 
     implementation(npm("google-map-react", "2.1.9", false))
     implementation(npm("@types/google-map-react", "2.1.0", false))


### PR DESCRIPTION
Dependency `org.koin:koin-core:3.0.1-alpha-3` did not existed any more. Project https://insert-koin.io/docs/setup/v3 suggests to use this dependancy: implementation "io.insert-koin:koin-core:$koin_version"