### PR TITLE
Jh 114 password reset

### DIFF
--- a/service-jehlomat/src/main/kotlin/api/OrganizationApi.kt
+++ b/service-jehlomat/src/main/kotlin/api/OrganizationApi.kt
@@ -43,7 +43,7 @@ fun Route.organizationApi(database: DatabaseService, jwtManager: JwtManager, mai
                         val orgId = database.insertOrganization(organization)
 
                         //todo: check if username should be filled in for organization different than organization name
-                        val user = User(0, registration.email, registration.name, registration.password,false, "", orgId, null, true)
+                        val user = User(0, registration.email, registration.name, registration.password, false, "", "", orgId, null, true)
                         database.insertUser(user)
 
                         mailer.sendOrganizationConfirmationEmail(organization.copy(id = orgId), registration.email)

--- a/service-jehlomat/src/main/kotlin/api/OrganizationApi.kt
+++ b/service-jehlomat/src/main/kotlin/api/OrganizationApi.kt
@@ -43,7 +43,7 @@ fun Route.organizationApi(database: DatabaseService, jwtManager: JwtManager, mai
                         val orgId = database.insertOrganization(organization)
 
                         //todo: check if username should be filled in for organization different than organization name
-                        val user = User(0, registration.email, registration.name, registration.password, false, "", "", orgId, null, true)
+                        val user = User(0, registration.email, registration.name, registration.password, false, "", orgId, null, true)
                         database.insertUser(user)
 
                         mailer.sendOrganizationConfirmationEmail(organization.copy(id = orgId), registration.email)

--- a/service-jehlomat/src/main/kotlin/api/PasswordResetApi.kt
+++ b/service-jehlomat/src/main/kotlin/api/PasswordResetApi.kt
@@ -1,58 +1,78 @@
 package api
 
 import io.ktor.application.*
+import io.ktor.features.*
 import io.ktor.http.*
+import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
+import model.password.*
 import services.DatabaseService
 import services.MailerService
 import services.RandomIdGenerator
-import utils.isValidMail
+import services.RequestValidationWrapper.Companion.validatePasswordResetRequest
+import utils.isValidPassword
+import java.time.Instant
 
 
 fun Route.passwordResetApi(database: DatabaseService, mailer: MailerService): Route {
     return route("/") {
-        get("/get-code/{email}") {
-            val email = call.parameters["email"]
+        post("/send-code") {
+            val request = call.receive<PasswordResetSendRequest>()
+            val userToChange = database.selectUserByEmail(request.email)
 
-            if (email == null || !email.isValidMail()) {
-                call.respond(HttpStatusCode.BadRequest, "Invalid email")
-            } else {
-                val userToChange = database.selectUserByEmail(email)
+            when {
+                userToChange == null -> {
+                    call.respond(HttpStatusCode.NotFound)
+                }
+                userToChange.verified.not() -> {
+                    call.respond(HttpStatusCode.PreconditionFailed, "User is not verified yet")
+                }
+                else -> {
+                    val resetUrlCode = RandomIdGenerator.generatePassResetUrlCode()
 
-                when {
-                    userToChange == null -> {
-                        call.respond(HttpStatusCode.NotFound)
-                    }
-                    userToChange.verified.not() -> {
-                        call.respond(HttpStatusCode.PreconditionFailed, "User is not verified yet")
-                    }
-                    else -> {
-                        val resetUrlCode = RandomIdGenerator.generatePassResetUrlCode()
-
-                        database.updateUser(userToChange.copy(
-                            // password = "SuperAdmin1", // TODO: why pass is being updated on every update user?
-                            passResetUrlCode = resetUrlCode
-                        ))
-
-                        // TODO: create Mailjet template
-                        // mailer.sendPassResetEmail(userToChange.email, resetUrlCode)
-
-                        call.respond(HttpStatusCode.OK)
-                    }
+                    database.invalidateOldPassResets(userToChange.id)
+                    database.insertPasswordReset(PasswordReset(
+                        id = 0,
+                        userId = userToChange.id,
+                        code = resetUrlCode,
+                        requestTime = Instant.now().epochSecond,
+                        callerIp = call.request.origin.remoteHost,
+                        status = PasswordResetStatus.NEW
+                    ))
+                    mailer.sendPassResetEmail(userToChange.email, resetUrlCode)
+                    call.respond(HttpStatusCode.NoContent)
                 }
             }
         }
 
+        post("/test-code") {
+            val request = call.receive<PasswordResetTestRequest>()
+            val passwordReset = database.selectPasswordReset(request.code)
+            val user = database.selectUserByEmail(request.email)
+
+            if(validatePasswordResetRequest(call, passwordReset, user)) {
+                call.respond(HttpStatusCode.NotFound)
+            }
+        }
+
         post("/save") {
-            // TODO:
-            //   get from
+            val request = call.receive<PasswordResetSaveRequest>()
+            val passwordReset = database.selectPasswordReset(request.code)
+            val user = database.selectUserByEmail(request.email)
 
-            // email
-            // code
-            // newPass
+            if (!validatePasswordResetRequest(call, passwordReset, user)) {
+                return@post
+            }
 
-            call.respond(HttpStatusCode.OK) // TODO: to test response
+            if (!request.password.isValidPassword()) {
+                call.respond(HttpStatusCode.BadRequest, "Wrong password format.")
+                return@post
+            }
+
+            database.updatePasswordResetStatus(passwordReset?.id!!, PasswordResetStatus.UTILIZED)
+            database.updateUserPassword(user?.id!!, request.password)
+            call.respond(HttpStatusCode.NoContent)
         }
     }
 }

--- a/service-jehlomat/src/main/kotlin/api/PasswordResetApi.kt
+++ b/service-jehlomat/src/main/kotlin/api/PasswordResetApi.kt
@@ -40,7 +40,7 @@ fun Route.passwordResetApi(database: DatabaseService, mailer: MailerService): Ro
                         callerIp = call.request.origin.remoteHost,
                         status = PasswordResetStatus.NEW
                     ))
-                    mailer.sendPassResetEmail(userToChange.email, resetUrlCode)
+                    mailer.sendPassResetEmail(userToChange.email, userToChange.id, resetUrlCode)
                     call.respond(HttpStatusCode.NoContent)
                 }
             }
@@ -49,17 +49,17 @@ fun Route.passwordResetApi(database: DatabaseService, mailer: MailerService): Ro
         post("/test-code") {
             val request = call.receive<PasswordResetTestRequest>()
             val passwordReset = database.selectPasswordReset(request.code)
-            val user = database.selectUserByEmail(request.email)
+            val user = database.selectUserById(request.userId)
 
             if(validatePasswordResetRequest(call, passwordReset, user)) {
-                call.respond(HttpStatusCode.NotFound)
+                call.respond(HttpStatusCode.NoContent)
             }
         }
 
         post("/save") {
             val request = call.receive<PasswordResetSaveRequest>()
             val passwordReset = database.selectPasswordReset(request.code)
-            val user = database.selectUserByEmail(request.email)
+            val user = database.selectUserById(request.userId)
 
             if (!validatePasswordResetRequest(call, passwordReset, user)) {
                 return@post

--- a/service-jehlomat/src/main/kotlin/api/PasswordResetApi.kt
+++ b/service-jehlomat/src/main/kotlin/api/PasswordResetApi.kt
@@ -1,0 +1,31 @@
+package api
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import services.DatabaseService
+import services.MailerService
+
+
+fun Route.passwordResetApi(database: DatabaseService, mailer: MailerService): Route {
+    return route("/") {
+        get("/get-code/{email}") {
+            val email = call.parameters["email"]
+
+            if (email == null) { // todo invalid format
+                call.respond(HttpStatusCode.BadRequest, "Invalid email")
+            } else {
+                // TODO: DB check, urlCode set, return urlCode; otherwise NotFound
+                call.respond(HttpStatusCode.OK, email) // TODO: to test response
+            }
+        }
+
+        post("/save") {
+            // email
+            // code
+            // newPass
+            call.respond(HttpStatusCode.OK, true) // TODO: to test response
+        }
+    }
+}

--- a/service-jehlomat/src/main/kotlin/api/Tables.kt
+++ b/service-jehlomat/src/main/kotlin/api/Tables.kt
@@ -1,6 +1,8 @@
 package api
 
 import model.*
+import model.password.PasswordReset
+import model.password.PasswordResetStatus
 import org.ktorm.dsl.QueryRowSet
 import org.ktorm.schema.*
 
@@ -36,7 +38,6 @@ open class UserTable(alias: String?) : Table<Nothing>("users", alias) {
     val password = varchar("password")
     val verified = boolean("verified")
     val verificationCode = varchar("verification_code")
-    val passResetUrlCode = varchar("pass_reset_url_code")
     val organizationId = int("organization_id")
     val teamId = int("team_id")
     val isAdmin = boolean("is_admin")
@@ -79,6 +80,23 @@ object TeamLocationTable: Table<Nothing>("team_locations") {
     val locationId = int("location_id")
 }
 
+object PasswordResetTable: BaseTable<PasswordReset>("password_resets") {
+    val passwordResetId = int("password_reset_id").primaryKey()
+    val userId = int("user_id")
+    val code = varchar("code")
+    val callerIp = varchar("caller_ip")
+    val requestTime = long("request_time")
+    val status = int("status")
+
+    override fun doCreateEntity(row: QueryRowSet, withReferences: Boolean) = PasswordReset(
+        id = row[passwordResetId]!!,
+        userId = row[userId]!!,
+        code = row[code]!!,
+        callerIp = row[callerIp]!!,
+        requestTime = row[requestTime]!!,
+        status = PasswordResetStatus.valueOf(row[status]!!)
+    )
+}
 
 object MCTable: Table<Nothing>("sph_mc") {
     val ogc_fid = int("ogc_fid").primaryKey()

--- a/service-jehlomat/src/main/kotlin/api/Tables.kt
+++ b/service-jehlomat/src/main/kotlin/api/Tables.kt
@@ -36,6 +36,7 @@ open class UserTable(alias: String?) : Table<Nothing>("users", alias) {
     val password = varchar("password")
     val verified = boolean("verified")
     val verificationCode = varchar("verification_code")
+    val passResetUrlCode = varchar("pass_reset_url_code")
     val organizationId = int("organization_id")
     val teamId = int("team_id")
     val isAdmin = boolean("is_admin")

--- a/service-jehlomat/src/main/kotlin/api/UserApi.kt
+++ b/service-jehlomat/src/main/kotlin/api/UserApi.kt
@@ -57,6 +57,7 @@ fun Route.userApi(databaseInstance: DatabaseService, jwtManager: JwtManager, mai
                             password = "",
                             verified = false,
                             verificationCode = verificationCode,
+                            passResetUrlCode = "",
                             organizationId = loggedInUser.organizationId,
                             teamId = null,
                             isAdmin = false

--- a/service-jehlomat/src/main/kotlin/api/UserApi.kt
+++ b/service-jehlomat/src/main/kotlin/api/UserApi.kt
@@ -57,7 +57,6 @@ fun Route.userApi(databaseInstance: DatabaseService, jwtManager: JwtManager, mai
                             password = "",
                             verified = false,
                             verificationCode = verificationCode,
-                            passResetUrlCode = "",
                             organizationId = loggedInUser.organizationId,
                             teamId = null,
                             isAdmin = false

--- a/service-jehlomat/src/main/kotlin/main/Application.kt
+++ b/service-jehlomat/src/main/kotlin/main/Application.kt
@@ -144,6 +144,9 @@ fun Application.module(testing: Boolean = false) {
         route("/api/v1/jehlomat/location") {
             locationApi(service)
         }
+        route("/api/v1/jehlomat/password-reset") {
+            passwordResetApi(service, mailer)
+        }
         route("/api/v1/jehlomat/team") {
             teamApi(service, jwtManager)
         }

--- a/service-jehlomat/src/main/kotlin/model/password/PasswordReset.kt
+++ b/service-jehlomat/src/main/kotlin/model/password/PasswordReset.kt
@@ -1,0 +1,10 @@
+package model.password
+
+data class PasswordReset(
+    val id: Int,
+    val userId: Int,
+    val code: String,
+    val callerIp: String,
+    val requestTime: Long,
+    val status: PasswordResetStatus
+)

--- a/service-jehlomat/src/main/kotlin/model/password/PasswordResetSaveRequest.kt
+++ b/service-jehlomat/src/main/kotlin/model/password/PasswordResetSaveRequest.kt
@@ -1,0 +1,10 @@
+package model.password
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PasswordResetSaveRequest(
+    val code: String,
+    val email: String,
+    val password: String,
+)

--- a/service-jehlomat/src/main/kotlin/model/password/PasswordResetSaveRequest.kt
+++ b/service-jehlomat/src/main/kotlin/model/password/PasswordResetSaveRequest.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class PasswordResetSaveRequest(
     val code: String,
-    val email: String,
+    val userId: Int,
     val password: String,
 )

--- a/service-jehlomat/src/main/kotlin/model/password/PasswordResetSendRequest.kt
+++ b/service-jehlomat/src/main/kotlin/model/password/PasswordResetSendRequest.kt
@@ -1,0 +1,8 @@
+package model.password
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PasswordResetSendRequest(
+    val email: String
+)

--- a/service-jehlomat/src/main/kotlin/model/password/PasswordResetStatus.kt
+++ b/service-jehlomat/src/main/kotlin/model/password/PasswordResetStatus.kt
@@ -1,0 +1,16 @@
+package model.password
+
+import api.PasswordResetTable.code
+
+enum class PasswordResetStatus(val code: Int) {
+    NEW(0),
+    UTILIZED(1),
+    OLDER(2);
+
+
+    companion object {
+        fun valueOf(code: Int): PasswordResetStatus {
+            return values().first { it.code == code }
+        }
+    }
+}

--- a/service-jehlomat/src/main/kotlin/model/password/PasswordResetTestRequest.kt
+++ b/service-jehlomat/src/main/kotlin/model/password/PasswordResetTestRequest.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class PasswordResetTestRequest(
     val code: String,
-    val email: String
+    val userId: Int
 )

--- a/service-jehlomat/src/main/kotlin/model/password/PasswordResetTestRequest.kt
+++ b/service-jehlomat/src/main/kotlin/model/password/PasswordResetTestRequest.kt
@@ -1,0 +1,9 @@
+package model.password
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PasswordResetTestRequest(
+    val code: String,
+    val email: String
+)

--- a/service-jehlomat/src/main/kotlin/model/user/User.kt
+++ b/service-jehlomat/src/main/kotlin/model/user/User.kt
@@ -14,6 +14,7 @@ data class User(
     @AuthRole(Role.UserOwner) val password: String,
     @UnchangeableByPut val verified: Boolean,
     @UnchangeableByPut val verificationCode: String,
+    @UnchangeableByPut val passResetUrlCode: String,
     @UnchangeableByPut val organizationId: Int,
     @AuthRole(Role.OrgAdmin) val teamId: Int?,
     @AuthRole(Role.OrgAdmin) val isAdmin: Boolean

--- a/service-jehlomat/src/main/kotlin/model/user/User.kt
+++ b/service-jehlomat/src/main/kotlin/model/user/User.kt
@@ -14,7 +14,6 @@ data class User(
     @AuthRole(Role.UserOwner) val password: String,
     @UnchangeableByPut val verified: Boolean,
     @UnchangeableByPut val verificationCode: String,
-    @UnchangeableByPut val passResetUrlCode: String,
     @UnchangeableByPut val organizationId: Int,
     @AuthRole(Role.OrgAdmin) val teamId: Int?,
     @AuthRole(Role.OrgAdmin) val isAdmin: Boolean

--- a/service-jehlomat/src/main/kotlin/services/DatabaseService.kt
+++ b/service-jehlomat/src/main/kotlin/services/DatabaseService.kt
@@ -1,13 +1,14 @@
 package services
 
 import api.*
-import kotlinx.html.ThScope
 import model.*
 import model.exception.UnknownLocationException
 import model.location.*
 import model.pagination.OrderByDefinition
 import model.pagination.PageInfo
 import model.pagination.toDsl
+import model.password.PasswordReset
+import model.password.PasswordResetStatus
 import model.syringe.SyringeFilter
 import model.syringe.OrderBySyringeColumn
 import model.team.Team
@@ -98,7 +99,6 @@ class DatabaseService(
             password = row[UserTable.password]!!,
             verified = row[UserTable.verified]!!,
             verificationCode = row[UserTable.verificationCode]!!,
-            passResetUrlCode = row[UserTable.passResetUrlCode]!!,
             organizationId = row[UserTable.organizationId]!!,
             teamId = row[UserTable.teamId],
             isAdmin = row[UserTable.isAdmin]!!
@@ -342,10 +342,46 @@ class DatabaseService(
         builder.set(it.username, user.username)
         builder.set(it.verified, user.verified)
         builder.set(it.verificationCode, user.verificationCode)
-        builder.set(it.passResetUrlCode, user.passResetUrlCode)
         builder.set(it.organizationId, user.organizationId)
         builder.set(it.teamId, user.teamId)
         builder.set(it.isAdmin, user.isAdmin)
+    }
+
+    fun insertPasswordReset(passwordReset: PasswordReset): Int {
+        return databaseInstance.insertAndGenerateKey(PasswordResetTable) {
+            set(it.userId, passwordReset.userId)
+            set(it.code, passwordReset.code)
+            set(it.callerIp, passwordReset.callerIp)
+            set(it.requestTime, passwordReset.requestTime)
+            set(it.status, passwordReset.status.code)
+        } as Int
+    }
+
+    fun invalidateOldPassResets(userId: Int) {
+        databaseInstance.update(PasswordResetTable) {
+            set(it.status, PasswordResetStatus.OLDER.code)
+            where {
+                (it.status eq PasswordResetStatus.NEW.code) and (it.userId eq userId)
+            }
+        }
+    }
+
+    fun updatePasswordResetStatus(id: Int, status: PasswordResetStatus) {
+        databaseInstance.update(PasswordResetTable) {
+            set(it.status, status.code)
+            where {
+                it.passwordResetId eq id
+            }
+        }
+    }
+
+    fun selectPasswordReset(code: String): PasswordReset? {
+        return databaseInstance
+            .from(PasswordResetTable)
+            .select()
+            .where { PasswordResetTable.code eq code }
+            .map { row -> PasswordResetTable.createEntity(row) }
+            .firstOrNull()
     }
 
     fun selectOrganizationById(id: Int): Organization? {

--- a/service-jehlomat/src/main/kotlin/services/DatabaseService.kt
+++ b/service-jehlomat/src/main/kotlin/services/DatabaseService.kt
@@ -384,6 +384,14 @@ class DatabaseService(
             .firstOrNull()
     }
 
+    fun selectPasswordResets(): List<PasswordReset> {
+        return databaseInstance
+            .from(PasswordResetTable)
+            .select()
+            .orderBy(PasswordResetTable.passwordResetId.asc())
+            .map{ row -> PasswordResetTable.createEntity(row) }
+    }
+
     fun selectOrganizationById(id: Int): Organization? {
         return databaseInstance
             .from(OrganizationTable)
@@ -762,7 +770,7 @@ class DatabaseService(
             .select(dbTriple.second)
             .where(dbTriple.third)
             .map { row -> row.getString(1)}
-            .firstOrNull()
+            .firstOrNull()?: throw UnknownLocationException("Unknown RUIAN location ${type}:${id}.")
     }
 
     fun resolveNearestTeam(gpsCoordinates: String): Team? {
@@ -797,6 +805,10 @@ class DatabaseService(
 
     fun cleanUsers(): Int {
         return databaseInstance.deleteAll(UserTable)
+    }
+
+    fun cleanPasswordResets(): Int {
+        return databaseInstance.deleteAll(PasswordResetTable)
     }
 
     fun cleanOrganizations(): Int {

--- a/service-jehlomat/src/main/kotlin/services/DatabaseService.kt
+++ b/service-jehlomat/src/main/kotlin/services/DatabaseService.kt
@@ -98,6 +98,7 @@ class DatabaseService(
             password = row[UserTable.password]!!,
             verified = row[UserTable.verified]!!,
             verificationCode = row[UserTable.verificationCode]!!,
+            passResetUrlCode = row[UserTable.passResetUrlCode]!!,
             organizationId = row[UserTable.organizationId]!!,
             teamId = row[UserTable.teamId],
             isAdmin = row[UserTable.isAdmin]!!
@@ -341,6 +342,7 @@ class DatabaseService(
         builder.set(it.username, user.username)
         builder.set(it.verified, user.verified)
         builder.set(it.verificationCode, user.verificationCode)
+        builder.set(it.passResetUrlCode, user.passResetUrlCode)
         builder.set(it.organizationId, user.organizationId)
         builder.set(it.teamId, user.teamId)
         builder.set(it.isAdmin, user.isAdmin)

--- a/service-jehlomat/src/main/kotlin/services/Mailer.kt
+++ b/service-jehlomat/src/main/kotlin/services/Mailer.kt
@@ -14,6 +14,7 @@ interface MailerService {
     fun sendOrganizationConfirmationEmail(organization: Organization, adminEmail: String)
     fun sendSyringeFindingConfirmation(email: String, syringeId: String)
     fun sendSyringeFinding(organization: Organization, email: String, syringeId: String)
+    fun sendPassResetEmail(email: String, resetUrlCode: String)
 }
 
 
@@ -33,6 +34,9 @@ class FakeMailer: MailerService {
     }
     override fun sendSyringeFinding(organization: Organization, email: String, syringeId: String) {
         println("sendSyringeFinding")
+    }
+    override fun sendPassResetEmail(email: String, resetUrlCode: String) {
+        println("sendPassResetEmail email: " + email + ", code: " + resetUrlCode)
     }
 }
 
@@ -163,5 +167,26 @@ class Mailer: MailerService {
 
         println(response.status)
         println(response.data)
+    }
+
+    @Throws(MailjetException::class)
+    override fun sendPassResetEmail(email: String, resetUrlCode: String) {
+        println("sendPassResetEmail TODO")
+        // TODO: update this
+
+        // val request = MailjetRequest(Emailv31.resource)
+        //     .property(
+        //         Emailv31.MESSAGES, prepareBodyWithLink(
+        //             3222932,
+        //             "Potvrzení zaznamenání nálezu",
+        //             "${publicUrl}api/v1/jehlomat/syringe/$syringeId/info",
+        //             email,
+        //             ""
+        //         )
+        //     )
+        // val response: MailjetResponse = client.post(request)
+
+        // println(response.status)
+        // println(response.data)
     }
 }

--- a/service-jehlomat/src/main/kotlin/services/Mailer.kt
+++ b/service-jehlomat/src/main/kotlin/services/Mailer.kt
@@ -15,7 +15,7 @@ interface MailerService {
     fun sendOrganizationConfirmationEmail(organization: Organization, adminEmail: String)
     fun sendSyringeFindingConfirmation(email: String, syringeId: String)
     fun sendSyringeFinding(organization: Organization, email: String, syringeId: String)
-    fun sendPassResetEmail(email: String, resetUrlCode: String)
+    fun sendPassResetEmail(email: String, userId: Int, resetUrlCode: String)
 }
 
 
@@ -36,8 +36,8 @@ class FakeMailer: MailerService {
     override fun sendSyringeFinding(organization: Organization, email: String, syringeId: String) {
         println("sendSyringeFinding")
     }
-    override fun sendPassResetEmail(email: String, resetUrlCode: String) {
-        println("sendPassResetEmail email: $email, code: $resetUrlCode")
+    override fun sendPassResetEmail(email: String, userId: Int, resetUrlCode: String) {
+        println("sendPassResetEmail email: $email, id: $userId, code: $resetUrlCode")
     }
 }
 
@@ -171,13 +171,13 @@ class Mailer: MailerService {
     }
 
     @Throws(MailjetException::class)
-    override fun sendPassResetEmail(email: String, resetUrlCode: String) {
+    override fun sendPassResetEmail(email: String, userId: Int, resetUrlCode: String) {
          val request = MailjetRequest(Emailv31.resource)
              .property(
                  Emailv31.MESSAGES, prepareBodyWithLink(
-                     3222932, // TODO template id
+                     3884047,
                      "Požadavek na reset hesla",
-                     "${publicUrl}uzivatel/heslo/?email=${email}&code=${resetUrlCode}",
+                     "${publicUrl}uzivatel/heslo/?userId=${userId}&code=${resetUrlCode}",
                      email,
                      ""
                  )

--- a/service-jehlomat/src/main/kotlin/services/Mailer.kt
+++ b/service-jehlomat/src/main/kotlin/services/Mailer.kt
@@ -1,4 +1,5 @@
 package services
+import api.UserTable.Companion.verificationCode
 import com.mailjet.client.errors.MailjetException
 import com.mailjet.client.MailjetClient
 import com.mailjet.client.MailjetRequest
@@ -36,7 +37,7 @@ class FakeMailer: MailerService {
         println("sendSyringeFinding")
     }
     override fun sendPassResetEmail(email: String, resetUrlCode: String) {
-        println("sendPassResetEmail email: " + email + ", code: " + resetUrlCode)
+        println("sendPassResetEmail email: $email, code: $resetUrlCode")
     }
 }
 
@@ -171,22 +172,16 @@ class Mailer: MailerService {
 
     @Throws(MailjetException::class)
     override fun sendPassResetEmail(email: String, resetUrlCode: String) {
-        println("sendPassResetEmail TODO")
-        // TODO: update this
-
-        // val request = MailjetRequest(Emailv31.resource)
-        //     .property(
-        //         Emailv31.MESSAGES, prepareBodyWithLink(
-        //             3222932,
-        //             "Potvrzení zaznamenání nálezu",
-        //             "${publicUrl}api/v1/jehlomat/syringe/$syringeId/info",
-        //             email,
-        //             ""
-        //         )
-        //     )
-        // val response: MailjetResponse = client.post(request)
-
-        // println(response.status)
-        // println(response.data)
+         val request = MailjetRequest(Emailv31.resource)
+             .property(
+                 Emailv31.MESSAGES, prepareBodyWithLink(
+                     3222932, // TODO template id
+                     "Požadavek na reset hesla",
+                     "${publicUrl}uzivatel/heslo/?email=${email}&code=${resetUrlCode}",
+                     email,
+                     ""
+                 )
+             )
+         client.post(request)
     }
 }

--- a/service-jehlomat/src/main/kotlin/services/RandomIdGenerator.kt
+++ b/service-jehlomat/src/main/kotlin/services/RandomIdGenerator.kt
@@ -4,6 +4,7 @@ import kotlin.random.Random
 
 private const val SYRINGE_ID_LENGTH = 8
 private const val REGISTRATION_CODE_LENGTH = 8
+private const val PASS_RESET_URL_CODE_LENGTH = 20
 
 class RandomIdGenerator {
 
@@ -16,6 +17,10 @@ class RandomIdGenerator {
 
         fun generateRegistrationCode(): String {
             return generateString(REGISTRATION_CODE_LENGTH)
+        }
+
+        fun generatePassResetUrlCode(): String {
+            return generateString(PASS_RESET_URL_CODE_LENGTH)
         }
 
         private fun generateString(stringLength: Int): String {

--- a/service-jehlomat/src/main/kotlin/services/RequestValidationWrapper.kt
+++ b/service-jehlomat/src/main/kotlin/services/RequestValidationWrapper.kt
@@ -3,6 +3,12 @@ package services
 import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.response.*
+import model.password.PasswordReset
+import model.password.PasswordResetStatus
+import model.user.User
+import java.time.Instant
+
+private const val PASSWORD_RESET_LIFESPAN_SEC = 7200
 
 class RequestValidationWrapper {
     companion object {
@@ -58,6 +64,36 @@ class RequestValidationWrapper {
             }
 
             return true
+        }
+
+        suspend fun validatePasswordResetRequest(
+            appCall: ApplicationCall,
+            passwordReset: PasswordReset?,
+            user: User?
+        ): Boolean {
+            return when {
+                passwordReset == null -> {
+                    appCall.respond(HttpStatusCode.NotFound)
+                    false
+                }
+                user == null -> {
+                    appCall.respond(HttpStatusCode.NotFound)
+                    false
+                }
+                user.id != passwordReset.userId -> {
+                    appCall.respond(HttpStatusCode.NotFound)
+                    false
+                }
+                passwordReset.status != PasswordResetStatus.NEW -> {
+                    appCall.respond(HttpStatusCode.NotFound)
+                    false
+                }
+                passwordReset.requestTime + PASSWORD_RESET_LIFESPAN_SEC < Instant.now().epochSecond -> {
+                    appCall.respond(HttpStatusCode.NotFound)
+                    false
+                }
+                else -> true
+            }
         }
     }
 }

--- a/service-jehlomat/src/main/resources/files/swagger.yaml
+++ b/service-jehlomat/src/main/resources/files/swagger.yaml
@@ -43,6 +43,23 @@ paths:
                 type: string
         '401':
           description: Name or password is wrong
+  /password-reset/get-code/{email}:
+    get:
+      summary: Obtain a password reset code
+      description: Returns a password reset code if user found.
+      produces:
+        - application/json
+      parameters:
+        - name: email
+          in: path
+          description: Email of user to be reset
+          required: true
+          type: string
+      responses:
+        '200':
+          description: "TODO: document urlCode"
+        '404':
+          description: User with this email not found
   /organization/{id}:
     get:
       summary: Find organization by id

--- a/service-jehlomat/src/main/resources/files/swagger.yaml
+++ b/service-jehlomat/src/main/resources/files/swagger.yaml
@@ -43,23 +43,66 @@ paths:
                 type: string
         '401':
           description: Name or password is wrong
-  /password-reset/get-code/{email}:
-    get:
-      summary: Obtain a password reset code
-      description: Returns a password reset code if user found.
-      produces:
-        - application/json
+  /password-reset/send-code:
+    post:
+      summary: Initiate a password reset
+      description: Send a reset email to the user
       parameters:
-        - name: email
-          in: path
-          description: Email of user to be reset
+        - in: body
+          name: body
           required: true
-          type: string
+          schema:
+            type: object
+            properties:
+              email:
+                type: string
       responses:
-        '200':
-          description: "TODO: document urlCode"
+        '204':
+          description: Email sent
         '404':
-          description: User with this email not found
+          description: User with sent email not found
+  /password-reset/test-code:
+    post:
+      summary: Test a password reset code
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              userId:
+                type: string
+              code:
+                type: string
+      responses:
+        '204':
+          description: The code is valid
+        '404':
+          description: The code doesn't exist or isn't valid
+  /password-reset/save:
+    post:
+      summary: Set a new password for specific user
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              userId:
+                type: string
+              code:
+                type: string
+              password:
+                type: string
+      responses:
+        '204':
+          description: The password is set
+        '400':
+          description: The password doesn't met criteria
+        '404':
+          description: The reset code isn't valid
   /organization/{id}:
     get:
       summary: Find organization by id

--- a/service-jehlomat/src/main/resources/sql/create_table.sql
+++ b/service-jehlomat/src/main/resources/sql/create_table.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS public.syringes CASCADE;
 DROP TABLE IF EXISTS public.team_locations CASCADE;
+DROP TABLE IF EXISTS public.password_resets CASCADE;
 DROP TABLE IF EXISTS public.users CASCADE;
 DROP TABLE IF EXISTS public.teams CASCADE;
 DROP TABLE IF EXISTS public.organizations CASCADE;
@@ -62,6 +63,18 @@ CREATE TABLE public.users(
         REFERENCES organizations(organization_id),
     CONSTRAINT fk_team FOREIGN KEY(team_id)
         REFERENCES teams(team_id)
+);
+
+CREATE TABLE public.password_resets(
+    password_reset_id SERIAL PRIMARY KEY,
+    user_id INT NOT NULL,
+    code TEXT,
+    caller_ip TEXT,
+    request_time BIGINT,
+    status INT,
+
+    CONSTRAINT fk_reset_user FOREIGN KEY(user_id)
+        REFERENCES users(user_id)
 );
 
 CREATE TABLE public.syringes(

--- a/service-jehlomat/src/test/kotlin/TestUtils.kt
+++ b/service-jehlomat/src/test/kotlin/TestUtils.kt
@@ -23,6 +23,7 @@ class TestUtils {
             every { mailer.sendOrganizationConfirmationEmail(any(), any()) } returns Unit
             every { mailer.sendSyringeFindingConfirmation(any(), any()) } returns Unit
             every { mailer.sendSyringeFinding(any(), any(), any()) } returns Unit
+            every { mailer.sendPassResetEmail(any(), any(), any()) } returns Unit
 
             return mailer
         }

--- a/service-jehlomat/src/test/kotlin/main/ApplicationTestPasswordReset.kt
+++ b/service-jehlomat/src/test/kotlin/main/ApplicationTestPasswordReset.kt
@@ -1,0 +1,183 @@
+package main
+
+import TestUtils
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import io.mockk.verify
+import junit.framework.TestCase
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import model.Organization
+import model.password.*
+import org.junit.Test
+import org.mindrot.jbcrypt.BCrypt
+import services.DatabaseService
+import services.MailerService
+import java.time.Instant
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+
+const val PASSWORD_RESET_API_PATH = "/api/v1/jehlomat/password-reset"
+const val PASSWORD_CODE = "password_code"
+
+class ApplicationTestPasswordReset {
+
+    private var defaultOrgId: Int = 0
+    private var defaultUserId: Int = 0
+    var database: DatabaseService = DatabaseService()
+    private lateinit var mailerMock: MailerService
+
+
+    @BeforeTest
+    fun beforeEach() {
+        database.cleanPasswordResets()
+        database.cleanUsers()
+        database.cleanTeams()
+        database.cleanOrganizations()
+        defaultOrgId = database.insertOrganization(Organization(0, "defaultOrgName", true))
+        defaultUserId = database.insertUser(USER.copy(organizationId = defaultOrgId, teamId = null))
+
+        mailerMock = TestUtils.mockMailer()
+    }
+
+    @AfterTest
+    fun afterEach() {
+        database.cleanPasswordResets()
+        database.cleanUsers()
+        database.cleanOrganizations()
+    }
+
+    @Test
+    fun testSendCodeOk() = withTestApplication({ module(testing = true) }) {
+        database.insertPasswordReset(PasswordReset(0, defaultUserId, "OLD_RESET", "", 0, PasswordResetStatus.NEW))
+
+        with(handleRequest(HttpMethod.Post, "$PASSWORD_RESET_API_PATH/send-code") {
+            addHeader("Content-Type", "application/json")
+            setBody(Json.encodeToString(PasswordResetSendRequest(email = USER.email)))
+        }) {
+            assertEquals(HttpStatusCode.NoContent, response.status())
+
+            val resets = database.selectPasswordResets();
+            assertEquals(PasswordResetStatus.OLDER, resets[0].status)
+
+            assertEquals(defaultUserId, resets[1].userId)
+            assertEquals(PasswordResetStatus.NEW, resets[1].status)
+            verify(exactly = 1) { mailerMock.sendPassResetEmail(USER.email, defaultUserId, resets[1].code) }
+        }
+    }
+
+    @Test
+    fun testSendCodeNotExisted() = withTestApplication(Application::module) {
+        with(handleRequest(HttpMethod.Post, "$PASSWORD_RESET_API_PATH/send-code") {
+            addHeader("Content-Type", "application/json")
+            setBody(Json.encodeToString(PasswordResetSendRequest(email = "wrong-email")))
+        }) {
+            assertEquals(HttpStatusCode.NotFound, response.status())
+        }
+    }
+
+    @Test
+    fun testSendTestCodeOk() = withTestApplication(Application::module) {
+        database.insertPasswordReset(PasswordReset(0, defaultUserId, PASSWORD_CODE, "", Instant.now().epochSecond, PasswordResetStatus.NEW))
+
+        with(handleRequest(HttpMethod.Post, "$PASSWORD_RESET_API_PATH/test-code") {
+            addHeader("Content-Type", "application/json")
+            setBody(Json.encodeToString(PasswordResetTestRequest(userId = defaultUserId, code = PASSWORD_CODE)))
+        }) {
+            assertEquals(HttpStatusCode.NoContent, response.status())
+        }
+    }
+
+    @Test
+    fun testSavePasswordOk() = withTestApplication(Application::module) {
+        database.insertPasswordReset(PasswordReset(0, defaultUserId, PASSWORD_CODE, "", Instant.now().epochSecond, PasswordResetStatus.NEW))
+        val newPassword = "noveHeslo1234"
+
+        with(handleRequest(HttpMethod.Post, "$PASSWORD_RESET_API_PATH/save") {
+            addHeader("Content-Type", "application/json")
+            setBody(Json.encodeToString(PasswordResetSaveRequest(userId = defaultUserId, code = PASSWORD_CODE, password = newPassword)))
+        }) {
+            assertEquals(HttpStatusCode.NoContent, response.status())
+            val resets = database.selectPasswordResets();
+            assertEquals(PasswordResetStatus.UTILIZED, resets[0].status)
+
+            val userDb = database.selectUserById(defaultUserId)!!
+            TestCase.assertTrue(BCrypt.checkpw(newPassword, userDb.password))
+        }
+    }
+
+    @Test
+    fun testSavePasswordWrongUser() = withTestApplication(Application::module) {
+        database.insertPasswordReset(PasswordReset(0, defaultUserId, PASSWORD_CODE, "", Instant.now().epochSecond, PasswordResetStatus.NEW))
+
+        with(handleRequest(HttpMethod.Post, "$PASSWORD_RESET_API_PATH/save") {
+            addHeader("Content-Type", "application/json")
+            setBody(Json.encodeToString(PasswordResetSaveRequest(userId = 123456, code = PASSWORD_CODE, password ="aaBB11aa")))
+        }) {
+            assertEquals(HttpStatusCode.NotFound, response.status())
+        }
+    }
+
+    @Test
+    fun testSavePasswordWrongCode() = withTestApplication(Application::module) {
+        database.insertPasswordReset(PasswordReset(0, defaultUserId, PASSWORD_CODE, "", Instant.now().epochSecond, PasswordResetStatus.NEW))
+
+        with(handleRequest(HttpMethod.Post, "$PASSWORD_RESET_API_PATH/save") {
+            addHeader("Content-Type", "application/json")
+            setBody(Json.encodeToString(PasswordResetSaveRequest(userId = defaultUserId, code = "wrong-code", password ="aaBB11aa")))
+        }) {
+            assertEquals(HttpStatusCode.NotFound, response.status())
+        }
+    }
+
+    @Test
+    fun testSavePasswordDifferentUser() = withTestApplication(Application::module) {
+        database.insertPasswordReset(PasswordReset(0, defaultUserId, PASSWORD_CODE, "", Instant.now().epochSecond, PasswordResetStatus.NEW))
+        val superAdminId = database.insertUser(SUPER_ADMIN.copy(organizationId = defaultOrgId, teamId = null))
+
+        with(handleRequest(HttpMethod.Post, "$PASSWORD_RESET_API_PATH/save") {
+            addHeader("Content-Type", "application/json")
+            setBody(Json.encodeToString(PasswordResetSaveRequest(userId = superAdminId, code = PASSWORD_CODE, password ="aaBB11aa")))
+        }) {
+            assertEquals(HttpStatusCode.NotFound, response.status())
+        }
+    }
+
+    @Test
+    fun testSavePasswordUsedReset() = withTestApplication(Application::module) {
+        database.insertPasswordReset(PasswordReset(0, defaultUserId, PASSWORD_CODE, "", Instant.now().epochSecond, PasswordResetStatus.UTILIZED))
+
+        with(handleRequest(HttpMethod.Post, "$PASSWORD_RESET_API_PATH/save") {
+            addHeader("Content-Type", "application/json")
+            setBody(Json.encodeToString(PasswordResetSaveRequest(userId = defaultUserId, code = PASSWORD_CODE, password ="aaBB11aa")))
+        }) {
+            assertEquals(HttpStatusCode.NotFound, response.status())
+        }
+    }
+
+    @Test
+    fun testSavePasswordOldReset() = withTestApplication(Application::module) {
+        database.insertPasswordReset(PasswordReset(0, defaultUserId, PASSWORD_CODE, "", 1, PasswordResetStatus.NEW))
+
+        with(handleRequest(HttpMethod.Post, "$PASSWORD_RESET_API_PATH/save") {
+            addHeader("Content-Type", "application/json")
+            setBody(Json.encodeToString(PasswordResetSaveRequest(userId = defaultUserId, code = PASSWORD_CODE, password ="aaBB11aa")))
+        }) {
+            assertEquals(HttpStatusCode.NotFound, response.status())
+        }
+    }
+
+    @Test
+    fun testSavePasswordWrongPassword() = withTestApplication(Application::module) {
+        database.insertPasswordReset(PasswordReset(0, defaultUserId, PASSWORD_CODE, "", Instant.now().epochSecond, PasswordResetStatus.NEW))
+
+        with(handleRequest(HttpMethod.Post, "$PASSWORD_RESET_API_PATH/save") {
+            addHeader("Content-Type", "application/json")
+            setBody(Json.encodeToString(PasswordResetSaveRequest(userId = defaultUserId, code = PASSWORD_CODE, password ="aa")))
+        }) {
+            assertEquals(HttpStatusCode.BadRequest, response.status())
+        }
+    }
+}


### PR DESCRIPTION
Oproti rozpracované verzi jsem provedl několik změn
- Endpoint pro vygenerování kódu je POST a email se posílá v body. Důvodem je sémantika GET vs POST requestů a pak aby nedocházelo k případnému zaznamenávání emailu uživatelů v access logu.
- Údaje o žádostech pro reset hesla jsou ve vlastní tabulce - výsledný počet atributů narostl a bylo by to tak nepřehledné + historizace pro auditing.
- Místo emailu se společně s kódem posílá user id - lepší soukromí.