### PR TITLE
hotfix: Fix the crash of the list of foundings

### DIFF
--- a/web-jehlomat/public/index.html
+++ b/web-jehlomat/public/index.html
@@ -30,7 +30,7 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <style>
-      @import url(http://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300ita‌​lic,400italic,500,500italic,700,700italic,900italic,900);
+      @import url(https://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300ita‌​lic,400italic,500,500italic,700,700italic,900italic,900);
       html,
       body,
       html * {

--- a/web-jehlomat/src/Components/Login/SetLogin.tsx
+++ b/web-jehlomat/src/Components/Login/SetLogin.tsx
@@ -7,6 +7,7 @@ import { IUser } from 'types';
 import { AxiosResponse } from 'axios';
 import { API, setApiToken } from 'config/baseURL';
 import { LINKS } from 'routes';
+import apiURL from 'utils/api-url';
 
 export const SetLogin: FC = () => {
     const token = useRecoilValue(tokenState);
@@ -20,7 +21,7 @@ export const SetLogin: FC = () => {
             setApiToken(token);
 
             const getUser = async (token: string) => {
-                const response: AxiosResponse<IUser> = await API.get('/api/v1/jehlomat/user/' + userId);
+                const response: AxiosResponse<IUser> = await API.get(apiURL.getUser(userId));
                 return response.data;
             };
 

--- a/web-jehlomat/src/screens/Nalezy/Components/SyringeRow.tsx
+++ b/web-jehlomat/src/screens/Nalezy/Components/SyringeRow.tsx
@@ -39,6 +39,8 @@ const SyringeRow: FunctionComponent<SyringeRowProps> = ({ syringe, selected, onS
 
     const isSelected = useMemo(() => selected.some(s => s.id === syringe.id), [selected]);
 
+    const username = syringe.createdBy ? syringe.createdBy.username : "-";
+
     return (
         <Row syringe={syringe}>
             <td>
@@ -50,7 +52,7 @@ const SyringeRow: FunctionComponent<SyringeRowProps> = ({ syringe, selected, onS
             <td>
                 <SyringeDemolishDate syringe={syringe} />
             </td>
-            <td>{syringe.createdBy.username}</td>
+            <td>{username}</td>
             <td>
                 <SyringeState syringe={syringe} />
             </td>

--- a/web-jehlomat/src/screens/Nalezy/types/Syringe.ts
+++ b/web-jehlomat/src/screens/Nalezy/types/Syringe.ts
@@ -4,7 +4,7 @@ import {Location} from "./Location";
 export interface Syringe {
     id: string;
     createdAt: number;
-    createdBy: Person;
+    createdBy?: Person;
     reservedTill?: number;
     reservedBy?: Person;
     demolishedAt?: number;


### PR DESCRIPTION
Fixed the crash of the list of foundings:
1. Fixed `https` for google fonts
<img width="640" alt="Screenshot 2022-04-24 at 18 30 21" src="https://user-images.githubusercontent.com/15198653/164986678-5e03180f-07cc-452a-905d-bbdbecc01505.png">

3. Fixed user API URL
<img width="638" alt="Screenshot 2022-04-24 at 18 30 25" src="https://user-images.githubusercontent.com/15198653/164986693-99d80d72-7f76-4a74-a48e-731e0078a70d.png">


5. Fixed the interface of the Syringe api
<img width="496" alt="Screenshot 2022-04-24 at 18 30 03" src="https://user-images.githubusercontent.com/15198653/164986670-8230439a-3f0a-45ea-9542-712580ed36b8.png">
<img width="784" alt="Screenshot 2022-04-24 at 18 29 59" src="https://user-images.githubusercontent.com/15198653/164986758-00d72225-0594-45e5-8ad1-59f6e52a947f.png">

