### PR TITLE
JH-222: fix: allow superadmin to see detail of all organizations

### DIFF
--- a/web-jehlomat/src/screens/Organizace/use-organisation.ts
+++ b/web-jehlomat/src/screens/Organizace/use-organisation.ts
@@ -24,7 +24,7 @@ export const useOrganisation = (onError?: TErrorCallback) => {
             if (isStatusSuccess(userResponse.status)) {
                 const orgResponse: AxiosResponse<IOrgData> = await API.get(apiURL.getOrganization(orgId));
                 if (isStatusSuccess(orgResponse.status)) {
-                    if (userResponse.data.organizationId.toString() !== orgId?.toString() || !userResponse.data.isAdmin) {
+                    if (!userResponse.data.isSuperAdmin && (userResponse.data.organizationId.toString() !== orgId?.toString() || !userResponse.data.isAdmin)) {
                         return onError?.('not-admin');
                     }
                     return {


### PR DESCRIPTION
@kisto I am leaving the current logic for displaying the profile of organization, just adding the condition that superadmin can see it for all organizations